### PR TITLE
Removed duplicate checkLoginAfterRefresh

### DIFF
--- a/src/facebook.js
+++ b/src/facebook.js
@@ -105,12 +105,6 @@ class FacebookLogin extends React.Component {
     });
   };
 
-  checkLoginAfterRefresh = (response) => {
-    if (response.status === 'unknown') {
-      window.FB.login(loginResponse => this.checkLoginState(loginResponse), true);
-    }
-  };
-
   checkLoginState = (response) => {
     this.setState({ isProcessing: false });
     if (response.authResponse) {
@@ -123,10 +117,10 @@ class FacebookLogin extends React.Component {
   };
 
   checkLoginAfterRefresh = (response) => {
-    if (response.status === 'unknown') {
-      window.FB.login(loginResponse => this.checkLoginState(loginResponse), true);
-    } else {
+    if (response.status === 'connected') {
       this.checkLoginState(response);
+    } else {
+      window.FB.login(loginResponse => this.checkLoginState(loginResponse), true);
     }
   };
 


### PR DESCRIPTION
- There were two duplicate functions of checkLoginAfterRefresh in the class, removed one.
- checkLoginAfterRefresh used "response.status === 'unknown'" to resend login request
- replaced that with response.status === 'connected' as 'unknown' and 'unauthorized' are the two other possibilities, and both should require a login request